### PR TITLE
fix: Reactへの依存性を下げるため、非制御コンポーネントformをRefからFormData APIを使うように修正

### DIFF
--- a/src/NewThread.jsx
+++ b/src/NewThread.jsx
@@ -1,14 +1,15 @@
 // NewThread.jsx
-import React, { useRef } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 
 const NewThread = () => {
-  const titleRef = useRef();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
 
-    const title = titleRef.current.value.trim();
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    const title = formData.get('title')?.trim();
     if (title) {
       try {
         const response = await fetch('https://railway.bulletinboard.techtrain.dev/threads', {
@@ -23,8 +24,7 @@ const NewThread = () => {
           throw new Error(`レスポンスステータス: ${response.status}`);
         }
 
-        // 成功したら入力をリセット
-        titleRef.current.value = '';
+        form.reset();
         console.log("スレッドが作成されました");
       } catch (error) {
         console.error("スレッド作成エラー:", error.message);
@@ -39,7 +39,7 @@ const NewThread = () => {
       <form onSubmit={handleSubmit}>
         <input
           type="text"
-          ref={titleRef}
+          name="title"
           placeholder="件名を入力してください"
           required
         />


### PR DESCRIPTION
現状のコードでは、form要素をstateを使わない非制御コンポーネントとして実装している。
refを利用しているが、refを使わずHTMLのFormData APIで書けることを知り、その方がReactへの依存性を下げ汎用性のあるコードとなるので、そのように修正する。

https://zenn.dev/gmomedia/articles/a78c94b32ad045#comment-cd60a818978e4d

https://developer.mozilla.org/ja/docs/Web/API/FormData